### PR TITLE
Fixed indent tracking

### DIFF
--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -1,6 +1,4 @@
 open Core
-open Codegenutil
-
 
 module type CodeGen = sig
   val convertToString : Ast.statement list -> string
@@ -9,7 +7,6 @@ end
 (***********************************************************************************************)
 module Expressions = struct
   (*CONVERSION of Expression*)
-
 
   let convertExpressionToString (exp : Ast.expression) main_tree : string =
     (*multiplication and division*)
@@ -153,15 +150,15 @@ module ConModule : CodeGen = struct
           (Expressions.convertExpressionToString upper main_tree)
           (Expressions.convertExpressionToString inc main_tree)
       ^ "{\n"
-      ^ helper statelist "" (countTabs + 1)^
-      numberOfTabs countTabs^ "}\n"
+      ^ helper statelist "" (countTabs + 1)
+      ^ numberOfTabs countTabs ^ "}\n"
     (*while loop conversion*)
     and whileLoopStr exp statelist countTabs =
       numberOfTabs countTabs ^ "while("
       ^ Expressions.convertExpressionToString exp main_tree
       ^ "){\n"
-      ^ helper statelist "" (countTabs + 1)^
-      numberOfTabs countTabs^ "}\n"
+      ^ helper statelist "" (countTabs + 1)
+      ^ numberOfTabs countTabs ^ "}\n"
     (*if statement conversion*)
     and ifStr exp statelist countTabs =
       numberOfTabs countTabs ^ "if("
@@ -196,7 +193,6 @@ module ConModule : CodeGen = struct
       | Ast.Function
           { name; parameters = args; return = prim; body = stateList }
         :: tl ->
-
           (*if the main function is empty then we ignore*)
           if String.equal name "main" && List.is_empty stateList then
             helper tl acc countTabs
@@ -238,7 +234,8 @@ module ConModule : CodeGen = struct
           numberOfTabs countTabs ^ helper tl (acc ^ "continue;\n") countTabs
       | Ast.Import _m :: _tl ->
           helper _tl (acc ^ "#include " ^ "m" ^ "\n") countTabs
-      | Ast.Comment _s :: _tl ->  numberOfTabs countTabs ^helper _tl (acc ^ "//" ^ _s ^ "\n") countTabs
+      | Ast.Comment _s :: _tl ->
+          numberOfTabs countTabs ^ helper _tl (acc ^ "//" ^ _s ^ "\n") countTabs
     in
 
     helper main_tree "" 0
@@ -247,7 +244,7 @@ end
 module GenerateHeader : CodeGen = struct
   let commonCLibraries =
     [ "stdio.h"; "stdlib.h"; "stdbool.h"; "string.h"; "math.h" ]
-  
+
   let commonCLibrariesToString (libraries : string list) : string =
     let rec helper (libraries : string list) (acc : string) : string =
       match libraries with
@@ -260,9 +257,8 @@ module GenerateHeader : CodeGen = struct
     let rec helper (tree_list : Ast.statement list) (acc : string) : string =
       match tree_list with
       | [] -> acc
-      | Ast.Function { name; parameters = args; return = prim; body = bdy } :: tl
-        ->
-
+      | Ast.Function { name; parameters = args; return = prim; body = bdy }
+        :: tl ->
           (*if the main function is empty*)
           if String.equal name "main" && List.is_empty bdy then helper tl acc
           else
@@ -275,5 +271,5 @@ module GenerateHeader : CodeGen = struct
       | _ :: tl -> helper tl acc
     in
 
-    commonCLibrariesToString commonCLibraries ^helper main_tree ""
+    commonCLibrariesToString commonCLibraries ^ helper main_tree ""
 end

--- a/src/codegenUtil.ml
+++ b/src/codegenUtil.ml
@@ -29,8 +29,9 @@ module Common = struct
   (*HELPER FUNCTIONS*)
 
   (*Convert arguments of function to string*)
- 
-  let declared_variables : (string, bool) Hashtbl.t = Hashtbl.create (module String)
+
+  let declared_variables : (string, bool) Hashtbl.t =
+    Hashtbl.create (module String)
 
   let is_variable_declared id =
     match Hashtbl.find declared_variables id with
@@ -40,7 +41,7 @@ module Common = struct
   let declare_variable id =
     Hashtbl.add_exn declared_variables ~key:id ~data:true
 
-  let clearHashTable  () = Hashtbl.clear declared_variables
+  let clearHashTable () = Hashtbl.clear declared_variables
 
   (*CORE FUNCTIONS*)
 
@@ -98,17 +99,18 @@ module Common = struct
     in
     helper expList ""
 
-    let convertArgsListString (argsList : (string * Ast.primitive) list) : string =
-      let rec helper (argsList : (string * Ast.primitive) list) : string =
-        match argsList with
-        | [] -> ""
-        | (id, prim) :: tl -> primitiveToString prim ^ " " ^ id ^ ", "^helper tl 
-      in
+  let convertArgsListString (argsList : (string * Ast.primitive) list) : string
+      =
+    let rec helper (argsList : (string * Ast.primitive) list) : string =
+      match argsList with
+      | [] -> ""
+      | (id, prim) :: tl -> primitiveToString prim ^ " " ^ id ^ ", " ^ helper tl
+    in
 
-      let result = helper argsList in 
+    let result = helper argsList in
 
-      if String.length result = 0 then result else
-      String.sub result ~pos:0 ~len:((String.length result) - 2)
+    if String.length result = 0 then result
+    else String.sub result ~pos:0 ~len:(String.length result - 2)
 
   let binaryToString (op : Ast.binaryOp option) : string =
     match op with

--- a/src/convert.ml
+++ b/src/convert.ml
@@ -38,9 +38,6 @@ let run_ops (listOfFiles : string list) =
         let outputFileH = "./" ^ renamePyFileToH currentFile in
         let includeStatement = "#include \"" ^ outputFileH ^ "\"" in
         let srcContent =
-          Stdio.printf "%s\n" (FileIO.readFile currentFile);
-          Stdio.printf "%s\n"
-            (FileIO.readFile currentFile |> Parse.to_ast |> Ast.showAst);
           FileIO.readFile currentFile
           |> Parse.to_ast |> Codegen.ConModule.convertToString
         in

--- a/src/dune
+++ b/src/dune
@@ -20,7 +20,7 @@
   (pps bisect_ppx)))
 
 (library
- (name codegenutil)
+ (name codegenUtil)
  (modules codegenUtil)
  (libraries base core ast)
  (preprocess
@@ -29,7 +29,7 @@
 (library
  (name codegen)
  (modules codegen)
- (libraries core ast codegenutil)
+ (libraries core ast codegenUtil)
  (preprocess
   (pps ppx_jane bisect_ppx)))
 

--- a/src/lex.ml
+++ b/src/lex.ml
@@ -161,12 +161,16 @@ let tokenize (file : string) : token list =
 
   let f (tokens, prev_indent) line =
     let line, cur_indent = strip_indent line in
-    let new_tokens = line |> split_and_process |> tokenize_line in
 
-    match compare cur_indent prev_indent with
-    | c when c > 0 -> (tokens @ [ Indent ] @ new_tokens, cur_indent)
-    | c when c < 0 -> (tokens @ [ Dedent ] @ new_tokens, cur_indent)
-    | _ -> (tokens @ new_tokens, cur_indent)
+    (* Propagate indent context if line is empty *)
+    if String.length line = 0 then (tokens @ [ Newline ], prev_indent)
+    else
+      let new_tokens = line |> split_and_process |> tokenize_line in
+
+      match compare cur_indent prev_indent with
+      | c when c > 0 -> (tokens @ [ Indent ] @ new_tokens, cur_indent)
+      | c when c < 0 -> (tokens @ [ Dedent ] @ new_tokens, cur_indent)
+      | _ -> (tokens @ new_tokens, cur_indent)
   in
 
   match file |> String.split_lines |> List.fold ~init ~f with

--- a/src/testPythonFiles/sample1.c
+++ b/src/testPythonFiles/sample1.c
@@ -1,7 +1,7 @@
-#include ".//testPythonFiles/sample1.h"
-int sampleFunction(int a, int b) {
-  while (a + b < 10) {
-    a + 1;
-    b + 2;
-  }
+#include ".//src/testPythonFiles/sample1.h"
+int sampleFunction(int a, int b){
+	while(a + b < 10){
+		 a + 1;
+		 b + 2;
+	}
 }

--- a/src/testPythonFiles/sample1.c
+++ b/src/testPythonFiles/sample1.c
@@ -1,2 +1,10 @@
 #include "./src/testPythonFiles/sample1.h"
-int sampleFunction(int a, int b) { return b; }
+#include m
+int sampleFunction(int a, int b) {
+  if (a > b) {
+    return a;
+  } else {
+    return b;
+  }
+}
+int main() { sample2.sampleFunctionTwo(1, sampleFunction(1, 2)); }

--- a/src/testPythonFiles/sample1.c
+++ b/src/testPythonFiles/sample1.c
@@ -1,7 +1,2 @@
-#include ".//src/testPythonFiles/sample1.h"
-int sampleFunction(int a, int b){
-	while(a + b < 10){
-		 a + 1;
-		 b + 2;
-	}
-}
+#include "./src/testPythonFiles/sample1.h"
+int sampleFunction(int a, int b) { return b; }

--- a/src/testPythonFiles/sample1.h
+++ b/src/testPythonFiles/sample1.h
@@ -4,3 +4,4 @@
 #include <string.h>
 #include <math.h>
 int sampleFunction(int a, int b);
+int main();

--- a/src/testPythonFiles/sample1.py
+++ b/src/testPythonFiles/sample1.py
@@ -1,6 +1,11 @@
+import sample2
+
+
 def sampleFunction(a: int, b: int) -> int:
-    while a + b < 10:
-        a += 1
-        b += 2
-        
-    return b
+    if a > b:
+        return a
+    else:
+        return b
+
+
+sample2.sampleFunctionTwo(1, sampleFunction(1, 2))

--- a/src/testPythonFiles/sample1.py
+++ b/src/testPythonFiles/sample1.py
@@ -2,3 +2,5 @@ def sampleFunction(a: int, b: int) -> int:
     while a + b < 10:
         a += 1
         b += 2
+        
+    return b

--- a/tests/endtoendtests.ml
+++ b/tests/endtoendtests.ml
@@ -2,111 +2,110 @@ open OUnit2
 
 (************** FUNCTION GENERATION TESTS **************)
 
-let withoutMain_eg_py = "def sampleFunction(a: int, b: int) -> int:
-return a + b
+let withoutMain_eg_py =
+  "def sampleFunction(a: int, b: int) -> int:\n\
+   return a + b\n\n\n\
+   e = 5\n\
+   f = 6\n\
+   e + f\n"
 
-
-e = 5
-f = 6
-e + f
-"
-
-let withoutMain_eg_c = "#include \".//testPythonFiles/sample1.h\"
-int sampleFunction(int a, int b){
-	return a + b;
-}
-int main(){
-	int e = 5;
-	int f = 6;
-	e + f;
-}
-"
+let withoutMain_eg_c =
+  "#include \".//testPythonFiles/sample1.h\"\n\
+   int sampleFunction(int a, int b){\n\
+   \treturn a + b;\n\
+   }\n\
+   int main(){\n\
+   \tint e = 5;\n\
+   \tint f = 6;\n\
+   \te + f;\n\
+   }\n"
 
 let testFunctions _ =
-  assert_equal  withoutMain_eg_c @@ (withoutMain_eg_py |> Parse.to_ast |> Codegen.ConModule.convertToString )
-
+  assert_equal withoutMain_eg_c
+  @@ (withoutMain_eg_py |> Parse.to_ast |> Codegen.ConModule.convertToString)
 
 (**************** CONDITIONAL TESTS **************************)
 
-let if_eg_py = "def sampleFunction(a: int, b: int) -> int:
-    if a > b:
-        return a
-    else:
-        return b
-"
+let if_eg_py =
+  "def sampleFunction(a: int, b: int) -> int:\n\
+  \    if a > b:\n\
+  \        return a\n\
+  \    else:\n\
+  \        return b\n"
 
-let if_eg_c = "#include \".//testPythonFiles/sample1.h\"
-  int sampleFunction(int a, int b){
-    if(a > b){
-      return a;
-    }else {
-      return b;
-    }
-  }
-  "
+let if_eg_c =
+  "#include \".//testPythonFiles/sample1.h\"\n\
+  \  int sampleFunction(int a, int b){\n\
+  \    if(a > b){\n\
+  \      return a;\n\
+  \    }else {\n\
+  \      return b;\n\
+  \    }\n\
+  \  }\n\
+  \  "
 
-let if_elif_eg_py = "def sampleFunction(a: int, b: int) -> int:
-  if a > b:
-      return a
-  elif a < b:
-      return b
-  else:
-      return a + b
-"
-let if_elif_eg_c = "#include \".//testPythonFiles/sample1.h\"
-  int sampleFunction(int a, int b){
-    if(a > b){
-      return a;
-    }	else if(a < b) {
-      return b;
-    }else{
-      return a + b;
-    }
-  }
-  "
+let if_elif_eg_py =
+  "def sampleFunction(a: int, b: int) -> int:\n\
+  \ \tif a > b:\n\
+  \      return a\n\
+  \  elif a < b:\n\
+  \      return b\n\
+  \  else:\n\
+  \      return a + b\n"
+
+let if_elif_eg_c =
+  "#include \".//testPythonFiles/sample1.h\"\n\
+  \  int sampleFunction(int a, int b){\n\
+  \    if(a > b){\n\
+  \      return a;\n\
+  \    }\telse if(a < b) {\n\
+  \      return b;\n\
+  \    }else{\n\
+  \      return a + b;\n\
+  \    }\n\
+  \  }\n\
+  \  "
 
 let testIf _ =
-  assert_equal if_eg_c @@ (if_eg_py |> Parse.to_ast |> Codegen.ConModule.convertToString );
-  assert_equal if_elif_eg_c @@ (if_elif_eg_py |> Parse.to_ast |> Codegen.ConModule.convertToString )
+  assert_equal if_eg_c
+  @@ (if_eg_py |> Parse.to_ast |> Codegen.ConModule.convertToString);
+  assert_equal if_elif_eg_c
+  @@ (if_elif_eg_py |> Parse.to_ast |> Codegen.ConModule.convertToString)
 
 (****************************** FUNCTION CALLS TESTS ******************************)
-let funcCall_py = "def sampleFunction(a: int, b: int) -> int:
-while a > b:
-    a -= 1
-return a
+let funcCall_py =
+  "def sampleFunction(a: int, b: int) -> int:\n\
+   \twhile a > b:\n\
+   \t\ta -= 1\n\
+   \treturn a\n\n\n\
+   def callFunction():\n\
+   \treturn sampleFunction(10, 5)\n\n\n\
+   callFunction()\n"
 
-
-def callFunction():
-return sampleFunction(10, 5)
-
-
-callFunction()
-"
-
-let funcCall_c = "#include \".//testPythonFiles/sample1.h\"
-int sampleFunction(int a, int b){
-	return a;
-}
-void callFunction(){
-	return sampleFunction(10, 5);
-}
-int main(){
-	callFunction();
-}
-"
+let funcCall_c =
+  "#include \".//testPythonFiles/sample1.h\"\n\
+   int sampleFunction(int a, int b){\n\
+   \treturn a;\n\
+   }\n\
+   void callFunction(){\n\
+   \treturn sampleFunction(10, 5);\n\
+   }\n\
+   int main(){\n\
+   \tcallFunction();\n\
+   }\n"
 
 let testFuncCall _ =
-  assert_equal funcCall_c @@ (funcCall_py |> Parse.to_ast |> Codegen.ConModule.convertToString )
+  assert_equal funcCall_c
+  @@ (funcCall_py |> Parse.to_ast |> Codegen.ConModule.convertToString)
 
-    
 (**************************** TESTS **************************)
-    let tests =
+let tests =
   "End to End Tests"
   >: test_list
        [
          "testFunctions" >:: testFunctions;
-          "testIf" >:: testIf;
-          "testFuncCall" >:: testFuncCall;
+         "testIf" >:: testIf;
+         "testFuncCall" >:: testFuncCall;
        ]
 
 let () = run_test_tt_main tests

--- a/tests/lextests.ml
+++ b/tests/lextests.ml
@@ -218,8 +218,8 @@ let test_tokenize _ =
       Bop "+";
       Value "b";
       Newline;
-      Dedent;
       Newline;
+      Dedent;
       Value "add";
       Lparen;
       Value "2";
@@ -228,7 +228,57 @@ let test_tokenize _ =
       Rparen;
       Newline;
     ]
-    ("def add(a: int, b: int) -> int:\n\treturn a + b \n\nadd(2+3) " |> tokenize)
+    ("def add(a: int, b: int) -> int:\n\treturn a + b \n\nadd(2+3)" |> tokenize);
+
+  assert_equal
+    [
+      Value "import";
+      Value "sample2";
+      Newline;
+      Newline;
+      FunDef;
+      Value "sampleFunction";
+      Lparen;
+      Value "a";
+      Colon;
+      IntDef;
+      Comma;
+      Value "b";
+      Colon;
+      IntDef;
+      Rparen;
+      Arrow;
+      IntDef;
+      Colon;
+      Newline;
+      Indent;
+      If;
+      Value "a";
+      Bop ">";
+      Value "b";
+      Colon;
+      Newline;
+      Indent;
+      Return;
+      Value "a";
+      Newline;
+      Dedent;
+      Else;
+      Colon;
+      Newline;
+      Indent;
+      Return;
+      Value "b";
+      Newline;
+      Dedent;
+      Dedent;
+    ]
+    ("import sample2\n\n\
+      def sampleFunction(a: int, b: int) -> int:\n\
+     \    if a > b: \n\
+     \        return a\n\
+     \    else:\n\
+     \        return b\n" |> tokenize)
 
 let tests =
   "Lex tests"


### PR DESCRIPTION
The end-to-end tests all fail right now, but I've verified the issue is because the input python strings are not validly formatted. You either need to use `\t` escape characters or 4 spaces. `parsetests` should have some good examples of validly-formatted multi-line strings. If there's other issues with the tests then it might be worth writing the code in a python file, letting a linter/formatter check for formatting, and then seeing if that can be correctly parsed. If the correctly formatted code doesn't parse then it might be a bug and not a formatting thing.